### PR TITLE
Add Headdot

### DIFF
--- a/controller/src/enhancements/player.rs
+++ b/controller/src/enhancements/player.rs
@@ -19,6 +19,7 @@ use crate::{
         AppSettings,
         EspBoxType,
         EspConfig,
+        EspHeadDot,
         EspHealthBar,
         EspPlayerSettings,
         EspSelector,
@@ -293,6 +294,54 @@ impl Enhancement for PlayerESP {
                     )
                     .thickness(esp_settings.skeleton_width)
                     .build();
+                }
+            }
+
+            if esp_settings.head_dot != EspHeadDot::None {
+                if let Some(head_bone_index) = entry_model
+                    .bones
+                    .iter()
+                    .position(|bone| bone.name == "head_0")
+                {
+                    if let Some(head_state) = entry.bone_states.get(head_bone_index) {
+                        if let (Some(head_position), Some(head_far)) = (
+                            view.world_to_screen(
+                                &(head_state.position
+                                    + nalgebra::Vector3::new(0.0, 0.0, esp_settings.head_dot_z)),
+                                true,
+                            ),
+                            view.world_to_screen(
+                                &(head_state.position
+                                    + nalgebra::Vector3::new(
+                                        0.0,
+                                        0.0,
+                                        esp_settings.head_dot_z + 2.0,
+                                    )),
+                                true,
+                            ),
+                        ) {
+                            let color = esp_settings
+                                .head_dot_color
+                                .calculate_color(player_rel_health, distance);
+
+                            let radius =
+                                (head_position.y - head_far.y) * esp_settings.head_dot_base_radius;
+                            let circle = draw.add_circle(head_position, radius, color);
+
+                            match esp_settings.head_dot {
+                                EspHeadDot::Filled => {
+                                    circle.filled(true).build();
+                                }
+                                EspHeadDot::NotFilled => {
+                                    circle
+                                        .filled(false)
+                                        .thickness(esp_settings.head_dot_thickness)
+                                        .build();
+                                }
+                                EspHeadDot::None => unreachable!(),
+                            }
+                        }
+                    }
                 }
             }
 

--- a/controller/src/settings/esp.rs
+++ b/controller/src/settings/esp.rs
@@ -187,6 +187,13 @@ pub enum EspTracePosition {
 }
 
 #[derive(Clone, Copy, Deserialize, Serialize, PartialEq, PartialOrd)]
+pub enum EspHeadDot {
+    None,
+    Filled,
+    NotFilled,
+}
+
+#[derive(Clone, Copy, Deserialize, Serialize, PartialEq, PartialOrd)]
 pub struct EspPlayerSettings {
     pub box_type: EspBoxType,
     pub box_color: EspColor,
@@ -221,6 +228,12 @@ pub struct EspPlayerSettings {
     pub info_flag_kit: bool,
     pub info_flag_flashed: bool,
     pub info_flags_color: EspColor,
+
+    pub head_dot: EspHeadDot,
+    pub head_dot_color: EspColor,
+    pub head_dot_thickness: f32,
+    pub head_dot_base_radius: f32,
+    pub head_dot_z: f32,
 }
 
 const ESP_COLOR_FRIENDLY: EspColor = EspColor::from_rgba(0.0, 1.0, 0.0, 0.75);
@@ -279,6 +292,12 @@ impl EspPlayerSettings {
             info_flag_kit: false,
             info_flag_flashed: false,
             info_flags_color: color.clone(),
+
+            head_dot: EspHeadDot::None,
+            head_dot_color: color.clone(),
+            head_dot_thickness: 2.0,
+            head_dot_base_radius: 3.0,
+            head_dot_z: 1.0,
         }
     }
 }

--- a/controller/src/settings/ui.rs
+++ b/controller/src/settings/ui.rs
@@ -62,6 +62,7 @@ use crate::{
     settings::{
         AppSettings,
         EspBoxType,
+        EspHeadDot,
         EspHealthBar,
         EspPlayerSettings,
         EspTracePosition,
@@ -715,6 +716,17 @@ impl SettingsUI {
                 }
 
                 {
+                    const HEAD_DOT_TYPES: [(EspHeadDot, &'static str); 3] = [
+                        (EspHeadDot::None, "No"),
+                        (EspHeadDot::Filled, "Filled"),
+                        (EspHeadDot::NotFilled, "Not Filled"),
+                    ];
+
+                    ui.set_next_item_width(COMBO_WIDTH);
+                    ui.combo_enum(obfstr!("head dot"), &HEAD_DOT_TYPES, &mut config.head_dot);
+                }
+
+                {
                     const TRACER_LINE_TYPES: [(EspTracePosition, &'static str); 7] = [
                         (EspTracePosition::None, "No"),
                         (EspTracePosition::TopLeft, "Top left"),
@@ -831,6 +843,40 @@ impl SettingsUI {
                         1.0,
                         10.0,
                         &mut config.skeleton_width,
+                    );
+
+                    ui.table_next_row();
+                    Self::render_esp_settings_player_style_color(
+                        ui,
+                        obfstr!("Head dot color"),
+                        &mut config.head_dot_color,
+                    );
+
+                    ui.table_next_row();
+                    Self::render_esp_settings_player_style_width(
+                        ui,
+                        obfstr!("Head dot thickness"),
+                        1.0,
+                        5.0,
+                        &mut config.head_dot_thickness,
+                    );
+
+                    ui.table_next_row();
+                    Self::render_esp_settings_player_style_width(
+                        ui,
+                        obfstr!("Head dot radius"),
+                        0.0,
+                        10.0,
+                        &mut config.head_dot_base_radius,
+                    );
+
+                    ui.table_next_row();
+                    Self::render_esp_settings_player_style_width(
+                        ui,
+                        obfstr!("Head dot z offset"),
+                        0.0,
+                        10.0,
+                        &mut config.head_dot_z,
                     );
 
                     ui.table_next_row();


### PR DESCRIPTION
- custom radius
- custom z offset
- filled / outline
- outline thickness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a customizable head dot feature for player rendering, allowing users to select between filled and unfilled dots.
	- Enhanced ESP settings with new configuration options for head dot color, thickness, radius, and z-offset.
  
- **Bug Fixes**
	- Improved rendering logic for head dots based on player distance and settings.

- **Documentation**
	- Updated user interface to include new ESP settings, enhancing usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->